### PR TITLE
Fix identifying multiline comments

### DIFF
--- a/calculate/calculate.go
+++ b/calculate/calculate.go
@@ -160,7 +160,7 @@ func (ctx *context) getCountersForCode(content string, language Language) (*Code
 
 		const pythonMultilineString = "\"\"\""
 		postCommentLine := ""
-		if strings.Contains(cleanLine, "/*") && !strings.Contains(cleanLine, "/*.") {
+		if isStartOfMultiLineComment(cleanLine) {
 			expectEndingComment = "*/"
 			commentIndex := strings.Index(cleanLine, "/*")
 			postCommentLine = strings.TrimSpace(cleanLine[2+commentIndex:])
@@ -224,6 +224,22 @@ func (ctx *context) getCountersForCode(content string, language Language) (*Code
 	counters.KeywordsComplexity = safeDivide(counters.Keywords, counters.LinesOfCode)
 
 	return counters, nil
+}
+
+func isStartOfMultiLineComment(cleanLine string) bool {
+	_, after, found := strings.Cut(cleanLine, "/*")
+
+	if !found {
+		return false
+	}
+
+	if len(after) > 1 {
+		nextChar := after[0:1]
+		if strings.ContainsAny(nextChar, "'\".") {
+			return false
+		}
+	}
+	return true
 }
 
 func (ctx *context) readFile(path string) (string, error) {

--- a/calculate/calculate.go
+++ b/calculate/calculate.go
@@ -3,13 +3,14 @@ package calculate
 import (
 	"code-complexity/options"
 	"fmt"
-	"github.com/gobwas/glob"
-	"golang.org/x/net/html/charset"
 	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/gobwas/glob"
+	"golang.org/x/net/html/charset"
 )
 
 type context struct {
@@ -159,7 +160,7 @@ func (ctx *context) getCountersForCode(content string, language Language) (*Code
 
 		const pythonMultilineString = "\"\"\""
 		postCommentLine := ""
-		if strings.Contains(cleanLine, "/*") {
+		if strings.Contains(cleanLine, "/*") && !strings.Contains(cleanLine, "/*.") {
 			expectEndingComment = "*/"
 			commentIndex := strings.Index(cleanLine, "/*")
 			postCommentLine = strings.TrimSpace(cleanLine[2+commentIndex:])

--- a/calculate/calculate_test.go
+++ b/calculate/calculate_test.go
@@ -203,16 +203,16 @@ func TestDogFood(t *testing.T) {
 	inRange(r, total.IndentationsNormalized, 2500, 3500)
 	inRange(r, total.IndentationsDiff, 400, 600)
 	inRange(r, total.IndentationsDiffNormalized, 400, 600)
-	inRange(r, total.IndentationsComplexity, 10, 12)
+	inRange(r, total.IndentationsComplexity, 11, 13)
 	inRange(r, total.IndentationsDiffComplexity*100, 150, 250)
 	inRange(r, total.KeywordsComplexity*100, 200, 250)
 
 	average := summary.CountersByLanguage["go"].Average
 	inRange(r, average.Lines, 300, 400)
 	inRange(r, average.LinesOfCode, 250, 300)
-	inRange(r, average.Keywords, 25, 35)
-	inRange(r, average.Indentations, 300, 350)
-	inRange(r, average.IndentationsNormalized, 300, 350)
+	inRange(r, average.Keywords, 30, 40)
+	inRange(r, average.Indentations, 350, 400)
+	inRange(r, average.IndentationsNormalized, 350, 400)
 	inRange(r, average.IndentationsDiff, 50, 60)
 	inRange(r, average.IndentationsDiffNormalized, 50, 60)
 	inRange(r, average.IndentationsComplexity, 1, 2)
@@ -315,6 +315,18 @@ int y = 2;
 	r.Equal(float64(0), math.Round(counters.IndentationsNormalized))
 	r.Equal(float64(0), math.Round(counters.IndentationsDiff))
 	r.Equal(float64(0), math.Round(counters.IndentationsDiffNormalized))
+
+	// language=java
+	code = `
+const path = 'dir/*';
+int x = 1;
+int y = 2;
+`
+	counters, err = getCountersForCode(code, "java")
+	r.Nil(err)
+	r.NotNil(counters)
+
+	r.Equal(float64(3), counters.LinesOfCode)
 
 	// language=java
 	code = `

--- a/calculate/calculate_test.go
+++ b/calculate/calculate_test.go
@@ -3,9 +3,6 @@ package calculate
 import (
 	"code-complexity/options"
 	"code-complexity/test_resources"
-	"github.com/otiai10/copy"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io/fs"
 	"io/ioutil"
 	"math"
@@ -13,6 +10,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func getFileCount(basePath string, includes []string, excludes []string) (float64, error) {
@@ -292,6 +293,23 @@ multiline comment
 	r.NotNil(counters)
 
 	r.Equal(float64(2), counters.LinesOfCode)
+	r.Equal(float64(0), counters.Keywords)
+	r.Equal(float64(0), counters.Indentations)
+	r.Equal(float64(0), math.Round(counters.IndentationsNormalized))
+	r.Equal(float64(0), math.Round(counters.IndentationsDiff))
+	r.Equal(float64(0), math.Round(counters.IndentationsDiffNormalized))
+
+	// language=java
+	code = `
+const path = "dir/*.ext";
+int x = 1;
+int y = 2;
+`
+	counters, err = getCountersForCode(code, "java")
+	r.Nil(err)
+	r.NotNil(counters)
+
+	r.Equal(float64(3), counters.LinesOfCode)
 	r.Equal(float64(0), counters.Keywords)
 	r.Equal(float64(0), counters.Indentations)
 	r.Equal(float64(0), math.Round(counters.IndentationsNormalized))

--- a/calculate/calculate_test.go
+++ b/calculate/calculate_test.go
@@ -191,7 +191,7 @@ func TestDogFood(t *testing.T) {
 	summary, err := Complexity(opts)
 	r.Nil(err)
 
-	r.Len(summary.CountersByLanguage, 1)
+	r.Len(summary.CountersByLanguage, 2)
 
 	r.Equal(float64(9), summary.CountersByLanguage["go"].NumberOfFiles)
 


### PR DESCRIPTION
Accidentally found that we identity path patterns (like os.find("/*.js")) to be the start of a multiline comment, thereby breaking lines of code calculation.
