### PR TITLE
Add support for different architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ build-osx:
 ifneq ($(shell uname -s),Darwin)
 	$(error this makefile assumes you're building from mac env)
 endif
-	GOARCH=amd64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-amd64 .
+	GOARCH=amd64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-x86_64 .
 	GOARCH=arm64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-arm64 .
 
 build-linux:
-	docker run --rm -v $(shell pwd):/app -w /app golang:1.22-alpine /bin/sh -c "GOARCH=arm64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-aarch64 ."
 	docker run --rm -v $(shell pwd):/app -w /app golang:1.22-alpine /bin/sh -c "GOARCH=amd64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-x86_64 ."
+	docker run --rm -v $(shell pwd):/app -w /app golang:1.22-alpine /bin/sh -c "GOARCH=arm64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-aarch64 ."
 
 clean:
 	rm -rf ./bin
@@ -34,7 +34,7 @@ test:
 
 verify-binaries:
 	$(info running binaries verification on osx, alpine, debiand, centos)
-	./bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-amd64 --version
+	./bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-x86_64 --version
 	./bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-arm64 --version
 	docker run --rm -v $(shell pwd)/bin:/app -w /app alpine /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-aarch64 --version
 	docker run --rm -v $(shell pwd)/bin:/app -w /app alpine /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-x86_64 --version

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,12 @@ build-osx:
 ifneq ($(shell uname -s),Darwin)
 	$(error this makefile assumes you're building from mac env)
 endif
-	GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx .
+	GOARCH=amd64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-amd64 .
+	GOARCH=arm64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-arm64 .
 
 build-linux:
-	docker run --rm -v $(shell pwd):/app -w /app golang:1.22-alpine /bin/sh -c "GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux ."
+	docker run --rm -v $(shell pwd):/app -w /app golang:1.22-alpine /bin/sh -c "GOARCH=arm64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-aarch64 ."
+	docker run --rm -v $(shell pwd):/app -w /app golang:1.22-alpine /bin/sh -c "GOARCH=amd64 GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -o bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-x86_64 ."
 
 clean:
 	rm -rf ./bin
@@ -32,10 +34,12 @@ test:
 
 verify-binaries:
 	$(info running binaries verification on osx, alpine, debiand, centos)
-	./bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx --version
-	docker run --rm -v $(shell pwd)/bin:/app -w /app alpine /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux --version
-	docker run --rm -v $(shell pwd)/bin:/app -w /app debian:buster /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux --version
-	docker run --rm -v $(shell pwd)/bin:/app -w /app centos:8 /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux --version
+	./bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-amd64 --version
+	./bin/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-osx-arm64 --version
+	docker run --rm -v $(shell pwd)/bin:/app -w /app alpine /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-aarch64 --version
+	docker run --rm -v $(shell pwd)/bin:/app -w /app alpine /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-x86_64 --version
+	docker run --rm -v $(shell pwd)/bin:/app -w /app debian:buster /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-aarch64 --version
+	docker run --rm -v $(shell pwd)/bin:/app -w /app debian:buster /app/$(BINARY_NAME)-$(shell $(GOCMD) run . --version | cut -d" " -f 3)-linux-x86_64 --version
 
 compress-bin:
 	find bin -type f -print -exec zip -j '{}'.zip '{}' \;

--- a/install.sh
+++ b/install.sh
@@ -12,12 +12,13 @@ pushd "$TMPDIR" > /dev/null
   mkdir -p complexity
   pushd complexity > /dev/null;
     distro=$(if [[ "$(uname -s)" == "Darwin" ]]; then echo "osx"; else echo "linux"; fi)
+    arch=$(uname -m)
     if [ -n "$1" ]
     then
       echo "Will download and install v$1"
-      curl -sSL --fail -o complexity.zip "https://github.com/apiiro/code-complexity/releases/download/v$1/complexity-$1-$distro.zip"
+      curl -sSL --fail -o complexity.zip "https://github.com/apiiro/code-complexity/releases/download/v$1/complexity-$1-$distro-$arch.zip"
     else
-      curl -s --fail https://api.github.com/repos/apiiro/code-complexity/releases/latest | grep "browser_download_url.*$distro.zip" | cut -d : -f 2,3 | tr -d \" | xargs curl -sSL --fail -o complexity.zip
+      curl -s --fail https://api.github.com/repos/apiiro/code-complexity/releases/latest | grep "browser_download_url.*$distro-$arch.zip" | cut -d : -f 2,3 | tr -d \" | xargs curl -sSL --fail -o complexity.zip
     fi
     unzip complexity.zip
     chmod +x complexity-*

--- a/install2.sh
+++ b/install2.sh
@@ -12,12 +12,13 @@ pushd "$TMPDIR" > /dev/null
   mkdir -p complexity
   pushd complexity > /dev/null;
     distro=$(if [[ "$(uname -s)" == "Darwin" ]]; then echo "osx"; else echo "linux"; fi)
+    arch=$(uname -m)
     if [ -n "$1" ]
     then
       echo "Will download and install v$1"
-      curl -sSL --fail -o complexity.zip "https://github.com/apiiro/code-complexity/releases/download/v$1/complexity-$1-$distro.zip"
+      curl -sSL --fail -o complexity.zip "https://github.com/apiiro/code-complexity/releases/download/v$1/complexity-$1-$distro-$arch.zip"
     else
-      curl -s --fail https://api.github.com/repos/apiiro/code-complexity/releases/latest | grep "browser_download_url.*$distro.zip" | cut -d : -f 2,3 | tr -d \" | xargs curl -sSL --fail -o complexity.zip
+      curl -s --fail https://api.github.com/repos/apiiro/code-complexity/releases/latest | grep "browser_download_url.*$distro-$arch.zip" | cut -d : -f 2,3 | tr -d \" | xargs curl -sSL --fail -o complexity.zip
     fi
     unzip complexity.zip
     chmod +x complexity-*

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const VERSION = "1.0.6"
+const VERSION = "1.0.7"
 
 func main() {
 	cli.AppHelpTemplate =


### PR DESCRIPTION
Split build to amd64 and arm64. Name the binaries based on the return value for `uname -m` on Darwin vs. Alpine.
Create `install2.sh` to stay compatible with older versions.